### PR TITLE
Removed illuminate/support and fixed mockery version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.x",
         "league/flysystem": "0.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master@dev"
+        "mockery/mockery": "0.9.5"
     },
     "autoload": {
         "psr-0": {

--- a/src/CanGelis/PDF/PDF.php
+++ b/src/CanGelis/PDF/PDF.php
@@ -75,6 +75,9 @@ class PDF {
 
 	/**
 	 * Initialize temporary file names and folders
+	 *
+	 * @param $cmd
+	 * @param null $tmpFolder
 	 */
 	public function __construct($cmd, $tmpFolder = null)
 	{
@@ -308,7 +311,9 @@ class PDF {
 	 */
 	protected function methodToParam($method)
 	{
-		return snake_case($method, "-");
+		$replace = '$1-$2';
+
+		return strtolower(preg_replace('/(.)([A-Z])/', $replace, $method));
 	}
 
 	/**


### PR DESCRIPTION
Set mockery/mockery to version 0.9.5 because this is the max version that is compatible with php 5.3. Removed the illuminate/support requirement and changed the snake_case call to use the same code without requiring the entire package.