### PR TITLE
Fixing mockery requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "league/flysystem": "0.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.5"
+        "mockery/mockery": "0.9.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Future versions of mockery will use 1.0. Changing the composer version to `0.9.*` so as not to break any project by specifying an exact version.