### PR TITLE
Upgrade to flysystem 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "league/flysystem": "0.3.*"
+        "league/flysystem": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.5"


### PR DESCRIPTION
Upgraded league/flysystem to version 1.0.
As you can read [on the documentation](http://flysystem.thephpleague.com/upgrade-to-1.0.0/), there should be no problem upgrading to version 1.0, since no actual adapters or caching mechanism are used within the library.
